### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ os:
   - linux
   #- osx # Disabled because 'mactex' is too huge (2+ GB) for Travis CI to install reliably
 julia:
-  - release
+  - 0.4
+  - 0.5
   #- nightly # Disabled because nightly seems to be moving fast and breaking things
              # will support 0.5 when it is released
-  - 0.4
 # Note: deps are tricky! Need full TeX/LaTeX, etc
 before_install:
  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update              ; fi


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested